### PR TITLE
Fix off-by-one error in max line length so lines do not wrap

### DIFF
--- a/wrap_plus.py
+++ b/wrap_plus.py
@@ -356,14 +356,14 @@ class WrapLinesPlusCommand(sublime_plugin.TextCommand):
     def _determine_width(self, width):
         if width == 0 and self.view.settings().get("wrap_width"):
             try:
-                width = int(self.view.settings().get("wrap_width"))
+                width = max(int(self.view.settings().get("wrap_width")) - 1, 0)
             except TypeError:
                 pass
 
         if width == 0 and self.view.settings().get("rulers"):
             # try and guess the wrap width from the ruler, if any
             try:
-                width = int(self.view.settings().get("rulers")[0])
+                width = max(int(self.view.settings().get("rulers")[0]) - 1, 0)
             except ValueError:
                 pass
             except TypeError:


### PR DESCRIPTION
Occasionally auto-formatted lines would wrap to the next line since they
exceeded the max length by one character. Subtracting 1 from the max line length
fixes the issues in these scenarios (both "wrap_width" and "rulers" were 81 in
my case; setting the max auto-formatted line length to 80 correctly formats a
previously overflowing comment).
