### PR TITLE
ST2 / ST3 LaTeX comment differences

### DIFF
--- a/wrap_plus.py
+++ b/wrap_plus.py
@@ -200,6 +200,7 @@ lettered_list = '(?:[\w][.)][\\t ])'
 bullet_list = '(?:[*+#-]+[\\t ])'
 list_pattern = re.compile('^[ \\t]*' + OR(numbered_list, lettered_list, bullet_list) + '[ \\t]*')
 latex_hack = '(:?\\\\)'
+latex_hack2 = '(:?%)'
 rest_directive = '(:?\\.\\.)'
 field_start = '(?:[:@])'  # rest, javadoc, jsdoc, etc.
 new_paragraph_pattern = re.compile('^[\\t ]*' +
@@ -214,7 +215,7 @@ sep_chars = '!@#$%^&*=+`~\'\":;.,?_-'
 sep_line = '[' + sep_chars + ']+[ \\t'+sep_chars+']*'
 
 # Break pattern is a little ambiguous.  Something like "# Header" could also be a list element.
-break_pattern = re.compile('^[\\t ]*' + OR(sep_line, OR(latex_hack, rest_directive) + '.*') + '$')
+break_pattern = re.compile('^[\\t ]*' + OR(sep_line, OR(latex_hack, latex_hack2, rest_directive) + '.*') + '$')
 pure_break_pattern = re.compile('^[\\t ]*' + sep_line + '$')
 
 email_quote = '[\\t ]*>[> \\t]*'


### PR DESCRIPTION
Hi! I have an inconsistent behaviour between ST2/ST3 for this normal latex code between two comments:

```
% better for a higher number of surfaces.
The run-time of the DT method does not depend on the number of surfaces and
scales well even for a high number of surfaces.
%
```

When the cursor is in the uncommented line and I perform a wrap in ST2 nothing changes, as intended. However, in ST3 I get

```
% better for a higher number of surfaces. The run-time of the DT method does not
depend on the number of surfaces and scales well even for a high number of
surfaces.
%
```

which is not only inconsistent but also wrong, because uncommented code is mixed with commented code. Is this solvable by some config parameters?
