### PR TITLE
Add keep_selection option

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -10,7 +10,10 @@
     // - "auto": Included only if Sublime's "word_wrap" is enabled (View ->
     //   Word Wrap) and Sublime's wrap column is not 0 (View -> Word Wrap
     //   Column -> Automatic).
-    "WrapPlus.include_line_endings": "auto"
+    "WrapPlus.include_line_endings": "auto",
     // Set the wrap column, overriding Sublime's "wrap_width" if not 0.
     //"WrapPlus.wrap_width": 78
+    // If true, the selection won't change after a wrap. Otherwise the cursor
+    // will be positioned below the last paragraph being wrapped
+    "WrapPlus.keep_selection": true
 }

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ There are a few settings you can tweak if you so desire.  You can set them in **
             </ul>
         </td>
     </tr>
+    <tr>
+        <td><code>"WrapPlus.keep_selection"</code></td>
+        <td><code>true</code></td>
+        <td>Whether or not to keep the current selection after a wrap. If not the cursor will be positioned below the last wrapped paragraph.</td>
+    </tr>
+
 </table>
 
 ### Advanced Configuration ###

--- a/wrap_plus.py
+++ b/wrap_plus.py
@@ -622,6 +622,12 @@ class WrapLinesPlusCommand(sublime_plugin.TextCommand):
 
         debug('paragraphs is %r', paragraphs)
 
+        # Clone all the regions in view.sel() and put them in a list called
+        # old_selection to maybe be restored later below
+        old_selection = []
+        for region in self.view.sel():
+            old_selection.append(region)
+
         if paragraphs:
             # Use view selections to handle shifts from the replace() command.
             self.view.sel().clear()
@@ -680,13 +686,20 @@ class WrapLinesPlusCommand(sublime_plugin.TextCommand):
                 else:
                     debug('replaced text is the same')
 
-        # Move cursor below the last paragraph.
-        s = self.view.sel()
-        end = s[len(s)-1].end()
-        line = self.view.line(end)
-        end = min(self.view.size(), line.end()+1)
-        self.view.sel().clear()
-        r = sublime.Region(end)
-        self.view.sel().add(r)
-        self.view.show(r)
+        keep_selection = self.view.settings().get('WrapPlus.keep_selection', True)
+        if keep_selection:
+            # Restore old selection
+            self.view.sel().clear()
+            for region in old_selection:
+                self.view.sel().add(region)
+        else:
+            # Move cursor below the last paragraph.
+            s = self.view.sel()
+            end = s[len(s)-1].end()
+            line = self.view.line(end)
+            end = min(self.view.size(), line.end()+1)
+            self.view.sel().clear()
+            r = sublime.Region(end)
+            self.view.sel().add(r)
+            self.view.show(r)
         debug_end()


### PR DESCRIPTION
As an emacs user I like to keep my cursor/selection like it was after performing a wrap. This PR adds the option to do this when wrapping. It's enabled by default.