### PR TITLE
Preserve leading whitespace for wrapped list items

### DIFF
--- a/wrap_plus.py
+++ b/wrap_plus.py
@@ -544,7 +544,9 @@ class WrapLinesPlusCommand(sublime_plugin.TextCommand):
         m = list_pattern.match(first_line)
         if m:
             initial_prefix = first_line[0:m.end()]
-            subsequent_prefix = ' '*self._width_in_spaces(initial_prefix)
+            stripped_prefix = initial_prefix.lstrip()
+            leading_whitespace = initial_prefix[:len(initial_prefix)-len(stripped_prefix)]
+            subsequent_prefix = leading_whitespace+' '*self._width_in_spaces(stripped_prefix)
         else:
             m = field_pattern.match(first_line)
             if m:


### PR DESCRIPTION
The previous implementation indented subsequent wrapped lines by transforming the entire initial prefix into spaces.

This implementation detects the leading whitespace present in the initial prefix, and uses the same whitespace (be it tabs, spaces, or some combination thereof) to indent subsequent lines. The non-whitespace portion of the initial prefix is still transformed into spaces as before.

For example:

Previous: 
![wrap_prev](https://cloud.githubusercontent.com/assets/918097/16939821/a94804d0-4d4a-11e6-9542-333887374081.png)

New:
![wrap_new](https://cloud.githubusercontent.com/assets/918097/16939824/af767dbe-4d4a-11e6-8661-927055241947.png)

