### PR TITLE
Distinguish a paragraph continuation from a real numbered list to fix #68

### DIFF
--- a/tests/test.txt
+++ b/tests/test.txt
@@ -29,6 +29,37 @@ I. foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo foo f
 * bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar
 ** bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar
 
+5. a numbered list starts with a numbered list marker
+5#55#.#) the marker can be fairly complicated, but
+5: markers must end with "." or ")"
+
+Test 6
+ 6. markers cannot have any indent
+
+Test 7: to be recognized, a numbered list after a paragraph must start at 1.
+7.1. for lists with subsections, the last section number is what matters
+7.2. test 7
+
+Test 8: otherwise, the numbered list is treated as a paragraph continuation
+1.8. the last section number is what matters
+     test 8, indent
+2.8. test 8 a
+     test 8 b
+
+ Test 9: paragraph continuation after an indented paragraph
+9. test 9
+
+Test 10: continuation after
+ test 10. an indented continuation
+10. test 10 c
+
+11. Wrapped lines must be indented; any amount of indentation is recognized.
+Otherwise,
+11. the next list item will not be recognized.
+
+#. Cupcake ipsum dolor sit amet marzipan faworki. Wafer I love croissant. Tart carrot cake pastry.
+#. Muffin ipsum dolor sit amet marzipan faworki. Wafer I love croissant. Tart carrot cake pastry.
+
 Numbered lists (not comments).
 # bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar
 ## bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar

--- a/wrap_plus.py
+++ b/wrap_plus.py
@@ -213,15 +213,16 @@ blank_line_pattern = re.compile(r'^[\t \n]*$')
 
 # This doesn't always work, but seems decent.
 numbered_list = r'(?:(?:[0-9#]+[.)])+[\t ])'
-lettered_list = r'(?:[\w][.)][\t ])'
+numbered_list_pattern = re.compile(numbered_list)
+last_number_pattern = re.compile(r'(\d+)(?!.*\d)')
+lettered_list = r'(?:[a-zA-Z][.)][\t ])'
 bullet_list = r'(?:[*+#-]+[\t ])'
 list_pattern = re.compile(r'^[ \t]*' + OR(numbered_list, lettered_list, bullet_list) + r'[ \t]*')
 latex_hack = r'(?:\\)(?!,|;|&|%|text|emph|cite|\w?(page)?ref|url|footnote|(La)*TeX)'
 rest_directive = r'(?:\.\.)'
 field_start = r'(?:[:@])'  # rest, javadoc, jsdoc, etc.
 new_paragraph_pattern = re.compile(r'^[\t ]*' +
-    OR(numbered_list, lettered_list, bullet_list,
-              field_start))
+    OR(lettered_list, bullet_list, field_start))
 space_prefix_pattern = re.compile(r'^[ \t]*')
 # XXX: Does not handle escaped colons in field name.
 fields = OR(r':[^:]+:', '@[a-zA-Z]+ ')
@@ -249,10 +250,36 @@ class WrapLinesPlusCommand(sublime_plugin.TextCommand):
         else:
             return self.view.full_line(region)
 
+    def _is_real_numbered_list(self, line_r, line, limit=10):
+        """Returns True if `line` is not a paragraph continuation."""
+        # We stop checking the list after `limit` lines to avoid quadratic
+        # runtime. For inputs like 100 lines of "2. ", this function is called
+        # in a loop over the input and also contains a loop over the input.
+        if limit == 0:
+            return True
+        if last_number_pattern.search(line).group(1) == '1':
+            return True
+        prev_line_r, prev_line = self._strip_view.prev_line(line_r)
+        if prev_line_r is None:
+            return True
+        if self._is_paragraph_break(prev_line_r, prev_line):
+            return True
+        if new_paragraph_pattern.match(prev_line):
+            return True
+        if numbered_list_pattern.match(prev_line):
+            return self._is_real_numbered_list(prev_line_r, prev_line, limit-1)
+        return False # previous line appears to be a normal paragraph
+
     def _is_paragraph_start(self, line_r, line):
         # Certain patterns at the beginning of the line indicate this is the
         # beginning of a paragraph.
-        return new_paragraph_pattern.match(line) != None
+        if new_paragraph_pattern.match(line):
+            return True
+        if numbered_list_pattern.match(line):
+            result = self._is_real_numbered_list(line_r, line)
+            debug('is {}a paragraph continuation'.format('not ' if result else ''))
+            return result
+        return False
 
     def _is_paragraph_break(self, line_r, line, pure=False):
         """A paragraph "break" is something like a blank line, or a horizontal line,


### PR DESCRIPTION
This is a new PR to implement your suggestion from #69.

I checked its output for tests/test.txt, and the only change is that `1.2. ` on
line 23 is now treated as a paragraph continuation, as expected.